### PR TITLE
switch helpers to use core from main artillery package

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const Lambda = require('aws-sdk/clients/lambda');
 const debug = require('debug')('engine:lambda');
 const A = require('async');
 const _ = require('lodash');
-const helpers = require('artillery-core/lib/engine_util');
+const helpers = require('artillery/core/lib/engine_util');
 
 function LambdaEngine (script, ee) {
   this.script = script;
@@ -77,8 +77,8 @@ LambdaEngine.prototype.step = function step (rs, ee, opts) {
       };
 
       const payload = typeof rs.invoke.payload === 'object'
-            ? JSON.stringify(rs.invoke.payload)
-            : String(rs.invoke.payload);
+        ? JSON.stringify(rs.invoke.payload)
+        : String(rs.invoke.payload);
 
       var params = {
         ClientContext: Buffer.from(rs.invoke.clientContext || '{}').toString('base64'),


### PR DESCRIPTION
Core was merged into the main artillery repo some while ago - https://github.com/shoreditch-ops/artillery/pull/457

Tests pass in this repo. Used this updated package with my other artillery lambda tests at work, and it was able to invoke them just fine. Let me know if there's any concerns!